### PR TITLE
Fix "no such directory" error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ set(SKYLAUNCH_LINKERSCRIPTS_DIR "${PROJECT_SOURCE_DIR}/linkerscripts")
 configure_file(linkerscripts/switch.specs.in ${PROJECT_BINARY_DIR}/switch.specs)
 
 # Generate version
-add_custom_target(__bf2mods_gittag COMMAND python3 ${PROJECT_SOURCE_DIR}/scripts/gittag.py WORKING_DIRECTORY ${PROJECT_BINARY_DIR} SOURCES ${PROJECT_BINARY_DIR}/gitversion.h)
+add_custom_target(__bf2mods_gittag COMMAND python3 ../scripts/gittag.py WORKING_DIRECTORY ${PROJECT_BINARY_DIR} SOURCES ${PROJECT_BINARY_DIR}/gitversion.h)
 set_source_files_properties(${PROJECT_BINARY_DIR}/gitversion.h PROPERTIES GENERATED TRUE)
 
 # Vendor libraries


### PR DESCRIPTION
For example, If ${PROJECT_SOURCE_DIR} is `d:\bf2mods`, 
you get `cmd.exe cd /d d:\bf2mods\build && python3 d:/bf2mods/scripts/gittag.py`. 
However, the cmake interprets this as follows.

`python3: can't open file '/d/bf2mods/build/D:/bf2mods/scripts/gittag.py': [Errno 2] No such file or directory
make[2]: *** [CMakeFiles/__bf2mods_gittag.dir/build.make:70: CMakeFiles/__bf2mods_gittag] Error 2
make[1]: *** [CMakeFiles/Makefile2:169: CMakeFiles/__bf2mods_gittag.dir/all] Error 2
make: *** [Makefile:136: all] Error 2`

Fixed this.