### PR TITLE
Forward logs from Skyline plugins

### DIFF
--- a/include/skylaunch/logger/Logger.hpp
+++ b/include/skylaunch/logger/Logger.hpp
@@ -42,3 +42,6 @@ namespace skylaunch::logger {
 
 	extern Logger* s_Instance;
 }; // namespace skylaunch::logger
+
+// for supporting stdout in Skyline plugins
+extern "C" void skyline_tcp_send_raw(const char*, size_t);

--- a/src/skylaunch/logger/Logger.cpp
+++ b/src/skylaunch/logger/Logger.cpp
@@ -108,3 +108,11 @@ void Logger::LogFormat(const char* format, ...) {
 #endif  // NOLOG
 
 };  // namespace skylaunch::logger
+
+// Skyline plugins expect this function to exist so that
+// stdout gets sent to the skyline TCP logger.
+// We have our own logger so we'll just send it there.
+void skyline_tcp_send_raw(const char* data, size_t size) {
+	if (!skylaunch::logger::s_Instance) return;
+	skylaunch::logger::s_Instance->Log(data, size);
+}


### PR DESCRIPTION
@RoccoDev's [fork of Skyline](https://github.com/RoccoDev/skyline/releases/tag/cross-game-local-logging), used in their xc3-file-loader, and my xc3-voice-liberator releases, essentially disables TCP logging when things like `printf` are used. If these are enabled then writes to this will crash when Xenomods is the plugin host because it expects `skyline_tcp_send_raw` to be exported and implemented. The release versions of these plugins don't crash Xenomods since those writes are excluded on release builds.

So I added an implementation for this to queue it through the Xenomods logger (without the formatting), so it can match the standard Skyline TCP logging behavior, which I couldn't get working outside of this, so it's cool that it does now!

Some snippets of sample log output (with prints enabled on voice liberator and a hacky SD card loader plugin thing)

```---------------------------------------------------------------
[xenomods|Debug] [hook-ng] Attempting to hook 0x00002d46808490 (no symbol name)...
Mounted SD card (result 0x0)
[xenomods|config~Info] Loaded config!
[skylaunch] Beginning initialization.
[PluginManager] Initializing plugins...
[xenomods|Debug] [hook-ng] Attempting to hook 0x00002d469985a0 (no symbol name)...
[xenomods|Debug] [hook-ng] Attempting to hook 0x00002d469985e0 (no symbol name)...
[xenomods|Debug] [hook-ng] Attempting to hook 0x00002d46973740 (no symbol name)...
[PluginManager] Opening plugins...
[TcpLogger] Logger initialized.
[PluginManager] Read rom:/skyline/plugins/libxc3_file_loader.nro
[PluginManager] Read rom:/skyline/plugins/libxc3_sd_save_loader.nro
[PluginManager] Read rom:/skyline/plugins/libxc3_voice_liberator.nro
[PluginManager] NRR size: 4096
[PluginManager] Loading plugins...
[PluginManager] Loaded 'rom:/skyline/plugins/libxc3_file_loader.nro'
[PluginManager] Loaded 'rom:/skyline/plugins/libxc3_sd_save_loader.nro'
[PluginManager] Loaded 'rom:/skyline/plugins/libxc3_voice_liberator.nro'
[PluginManager] Running `main` for rom:/skyline/plugins/libxc3_file_loader.nro
[PluginManager] Finished running `main` for 'rom:/skyline/plugins/libxc3_file_loader.nro' (0x0)
[PluginManager] Running `main` for rom:/skyline/plugins/libxc3_sd_save_loader.nro
[1970-01-01 00:00:00] [XC3-SD-Save-Loader] xc3_sd_save_loader loaded
[1970-01-01 00:00:00] [XC3-SD-Save-Loader] SD card already mounted.
[1970-01-01 00:00:00] [XC3-SD-Save-Loader] Checking for saves directory sd:/xc3-saves
[1970-01-01 00:00:00] [XC3-SD-Save-Loader] Mod initialized
[1970-01-01 00:00:00] [XC3-SD-Save-Loader] Loading allow list from sd:/xc3-saves/allow-list.txt
[1970-01-01 00:00:00] [XC3-SD-Save-Loader] Adding bf3game01.sav to allow list
[1970-01-01 00:00:00] [XC3-SD-Save-Loader] Adding bf3dlc01.sav to allow list
[PluginManager] Finished running `main` for 'rom:/skyline/plugins/libxc3_sd_save_loader.nro' (0x0)
[PluginManager] Running `main` for rom:/skyline/plugins/libxc3_voice_liberator.nro
[XC3-Voice-Liberator] Loading...
[XC3-Voice-Liberator] Loaded!
[PluginManager] Finished running `main` for 'rom:/skyline/plugins/libxc3_voice_liberator.nro' (0x0)
[xenomods|Debug] [hook-ng] Attempting to hook 0x00002d46abe8c0 (no symbol name)...
[xenomods|Debug] Setting up debug stuff...
[xenomods|Debug] Setting up camera tools...

…


[2023-11-12 18:16:12] [XC3-SD-Save-Loader] Game has mounted save data. Copying files.
[2023-11-12 18:16:12] [XC3-SD-Save-Loader] Copying sd:/xc3-saves/bf3dlc01.sav to save:/bf3dlc01.sav
[2023-11-12 18:16:13] [XC3-SD-Save-Loader] Done copying files
[2023-11-12 18:16:20] [XC3-SD-Save-Loader] Overriding save:/bf3dlc01.sav with sd:/xc3-saves/bf3dlc01.sav
[XC3-Voice-Liberator] Loading Base Game VO
[XC3-Voice-Liberator] Loading en_dlc2.pck

…

[XC3-Voice-Liberator] Loading vo_035.bnk
[2023-11-12 18:16:49] [XC3-SD-Save-Loader] Overriding save:/bf3dlc01.sav with sd:/xc3-saves/bf3dlc01.sav
[2023-11-12 18:17:01] [XC3-SD-Save-Loader] Overriding save:/bf3dlc01.sav with sd:/xc3-saves/bf3dlc01.sav
[2023-11-12 18:17:08] [XC3-SD-Save-Loader] Overriding save:/bf3dlc01.sav with sd:/xc3-saves/bf3dlc01.sav
[2023-11-12 18:17:37] [XC3-SD-Save-Loader] Mirroring save from save:/bf3dlc01.sav to sd:/xc3-saves/bf3dlc01.sav

…
```