### PR TITLE
Freecam combo axis

### DIFF
--- a/docs/menu.md
+++ b/docs/menu.md
@@ -38,8 +38,8 @@ Landmark ids can be found [here](https://xenobladedata.github.io/xb2/bdat/common
 ###### Control Options
 | Option                          | Description                                                                                                                | Default             |
 |---------------------------------|----------------------------------------------------------------------------------------------------------------------------|---------------------|
-| Move type                       | Selects which axies the camera moves along with the left stick.                                                            | XZ                  |
-| L+R Move type                   | Selects which axies the camera moves along with the left stick when L+R is held down.                                      | XY                  |
+| Move type                       | Selects which axes the camera moves along with the left stick.                                                             | XZ                  |
+| L+R Move type                   | Selects which axes the camera moves along with the left stick when L+R is held down.                                       | XY                  |
 | Freeze X/Y/Z                    | Freezes movement on the specified axis.                                                                                    | false, false, false |
 | Global X/Y/Z                    | Makes movement global (world relative) as opposed to local (view relative) for the specified axis.                         | false, false, false |
 | Freecam speed (m/s)             | Controls the movement speed of the freecam.                                                                                | 8.0                 |

--- a/docs/menu.md
+++ b/docs/menu.md
@@ -39,6 +39,7 @@ Landmark ids can be found [here](https://xenobladedata.github.io/xb2/bdat/common
 | Option                          | Description                                                                                                                | Default             |
 |---------------------------------|----------------------------------------------------------------------------------------------------------------------------|---------------------|
 | Move type                       | Selects which axies the camera moves along with the left stick.                                                            | XZ                  |
+| L+R Move type                   | Selects which axies the camera moves along with the left stick when L+R is held down.                                      | XY                  |
 | Freeze X/Y/Z                    | Freezes movement on the specified axis.                                                                                    | false, false, false |
 | Global X/Y/Z                    | Makes movement global (world relative) as opposed to local (view relative) for the specified axis.                         | false, false, false |
 | Freecam speed (m/s)             | Controls the movement speed of the freecam.                                                                                | 8.0                 |

--- a/src/xenomods/modules/CameraTools.cpp
+++ b/src/xenomods/modules/CameraTools.cpp
@@ -118,6 +118,7 @@ namespace xenomods {
 		.freecamOn = false,
 		.relativeToPlayer = false,
 		.moveAxis = FreecamSettings::MoveAxis::XZ,
+		.comboMoveAxis = FreecamSettings::MoveAxis::XY,
 		.isFreezePos = { false, false, false },
 		.isGlobalPos = { false, false, false },
 		.isGlobalRot = { false, true, false },
@@ -211,7 +212,9 @@ namespace xenomods {
 		glm::vec3 move { 0, 0, 0 };
 		glm::vec3 perAxisMove { 0, 0, 0 };
 
-		switch(set->moveAxis) {
+		CameraTools::FreecamSettings::MoveAxis moveAxis = debugInput->InputHeld(Keybind::CAMERA_COMBO) ? set->comboMoveAxis : set->moveAxis;
+
+		switch(moveAxis) {
 			case CameraTools::FreecamSettings::MoveAxis::XZ:
 				move = { lStick.x, 0, -lStick.y };
 				break;
@@ -339,6 +342,8 @@ namespace xenomods {
 
 		ImGui::PushItemWidth(64.f);
 		imguiext::EnumComboBox("Move type", &Settings.moveAxis);
+		ImGui::SameLine();
+		imguiext::EnumComboBox("L+R Move type", &Settings.comboMoveAxis);
 		ImGui::PopItemWidth();
 
 		ImGui::Checkbox("Freeze X", &Settings.isFreezePos[0]);

--- a/src/xenomods/modules/CameraTools.hpp
+++ b/src/xenomods/modules/CameraTools.hpp
@@ -20,6 +20,7 @@ namespace xenomods {
 			bool freecamOn;
 			bool relativeToPlayer;
 			MoveAxis moveAxis;
+			MoveAxis comboMoveAxis;
 			bool isFreezePos[3];
 			bool isGlobalPos[3];
 			bool isGlobalRot[3];


### PR DESCRIPTION
The new movement customizability features are great!

Wondering what you think on this one. I personally like having an easy way to switch between sets of axis movements. Since Combo + LStick is effectively doing the same as LStick, I thought it might be a good idea to have an alternate axis set on LStick if Combo is held down. If the behavior is undesired then one can simply set the move axes settings to be the same axes.

![image](https://github.com/BlockBuilder57/xenomods/assets/130002142/0acb89f3-5d4d-478b-af91-53afcae93107)
