### PR TITLE
Add debug window for memory allocators

### DIFF
--- a/include/xenomods/engine/mtl/Allocator.hpp
+++ b/include/xenomods/engine/mtl/Allocator.hpp
@@ -4,17 +4,31 @@
 
 namespace mtl {
 
-	struct ALLOC_HANDLE {
-	   public:
-		unsigned long actual;
+	// Unofficial name
+	struct AllocHandle {
+		public:
+			uint32_t regionId;
 
-		// xenomods from here
-		inline bool IsValid() {
-			return actual != -1ul;
-		}
-		inline ALLOC_HANDLE* Ptr() {
-			return reinterpret_cast<ALLOC_HANDLE*>(actual);
-		}
+			// xenomods from here
+			inline bool IsValid() {
+				return regionId > 0;
+			}
+	};
+
+	struct ALLOC_HANDLE {
+		private:
+			const AllocHandle* handle;
+
+		public:
+			// xenomods
+			ALLOC_HANDLE(const AllocHandle* handle) : handle(handle) {}
+	};
+
+	enum AllocatorType {
+		ALLOCATOR_NULL = 0,
+		ALLOCATOR_DLMALLOC = 1,
+		ALLOCATOR_ASSET = 2,
+		ALLOCATOR_BF3 = 3
 	};
 
 }

--- a/include/xenomods/engine/mtl/Allocator.hpp
+++ b/include/xenomods/engine/mtl/Allocator.hpp
@@ -25,9 +25,14 @@ namespace mtl {
 	};
 
 	enum AllocatorType {
+		/// Present in all games, allocator that always returns `nullptr`
 		ALLOCATOR_NULL = 0,
+		/// Doug Lea's memory allocator. Used extensively in DE/2, and occasionally in 3.
+		/// Usually nested (smaller regions from bigger arenas)
 		ALLOCATOR_DLMALLOC = 1,
+		/// `AssetAllocator`, used in DE/2, unused in 3 (but still present)
 		ALLOCATOR_ASSET = 2,
+		/// Similar to jemalloc, maps virtual pages. Introduced in 3.
 		ALLOCATOR_BF3 = 3
 	};
 

--- a/include/xenomods/engine/mtl/Allocator.hpp
+++ b/include/xenomods/engine/mtl/Allocator.hpp
@@ -6,22 +6,24 @@ namespace mtl {
 
 	// Unofficial name
 	struct AllocHandle {
-		public:
-			uint32_t regionId;
+	   public:
+		uint32_t regionId;
 
-			// xenomods from here
-			inline bool IsValid() {
-				return regionId > 0;
-			}
+		// xenomods from here
+		inline bool IsValid() {
+			return regionId > 0;
+		}
 	};
 
 	struct ALLOC_HANDLE {
-		private:
-			const AllocHandle* handle;
+	   private:
+		const AllocHandle* handle;
 
-		public:
-			// xenomods
-			ALLOC_HANDLE(const AllocHandle* handle) : handle(handle) {}
+	   public:
+		// xenomods
+		ALLOC_HANDLE(const AllocHandle* handle)
+			: handle(handle) {
+		}
 	};
 
 	enum AllocatorType {
@@ -36,4 +38,4 @@ namespace mtl {
 		ALLOCATOR_BF3 = 3
 	};
 
-}
+} // namespace mtl

--- a/include/xenomods/engine/mtl/MemManager.hpp
+++ b/include/xenomods/engine/mtl/MemManager.hpp
@@ -6,29 +6,29 @@
 
 namespace mtl {
 
-    class MemManager {
-        public:
-            static bool getMemoryInfo(mtl::ALLOC_HANDLE, mtl::MemoryInfo*);
+	class MemManager {
+	   public:
+		static bool getMemoryInfo(mtl::ALLOC_HANDLE, mtl::MemoryInfo*);
 
-            // xenomods
-            /// `mtl::MemoryInfo` accessor compatible with all games
-            static bool GET_MEMORY_INFO(mtl::ALLOC_HANDLE handle, mtl::MemoryInfo* out) {
+		// xenomods
+		/// `mtl::MemoryInfo` accessor compatible with all games
+		static bool GET_MEMORY_INFO(mtl::ALLOC_HANDLE handle, mtl::MemoryInfo* out) {
 #if !XENOMODS_CODENAME(bf3)
-                return getMemoryInfo(handle, out);
+			return getMemoryInfo(handle, out);
 #else
-                uintptr_t getMemoryInfo;
-                if (xenomods::version::RuntimeVersion() == xenomods::version::SemVer::v2_0_0)
-                    getMemoryInfo = skylaunch::utils::AddrFromBase(0x710128a670);
-                else if (xenomods::version::RuntimeVersion() == xenomods::version::SemVer::v2_1_0)
-                    getMemoryInfo = skylaunch::utils::AddrFromBase(0x710128a9a0);
-                else if (xenomods::version::RuntimeVersion() == xenomods::version::SemVer::v2_1_1)
-                    getMemoryInfo = skylaunch::utils::AddrFromBase(0x710128a9e0);
-                else if (xenomods::version::RuntimeVersion() == xenomods::version::SemVer::v2_2_0)
-                    getMemoryInfo = skylaunch::utils::AddrFromBase(0x710128b550);
+			uintptr_t getMemoryInfo;
+			if(xenomods::version::RuntimeVersion() == xenomods::version::SemVer::v2_0_0)
+				getMemoryInfo = skylaunch::utils::AddrFromBase(0x710128a670);
+			else if(xenomods::version::RuntimeVersion() == xenomods::version::SemVer::v2_1_0)
+				getMemoryInfo = skylaunch::utils::AddrFromBase(0x710128a9a0);
+			else if(xenomods::version::RuntimeVersion() == xenomods::version::SemVer::v2_1_1)
+				getMemoryInfo = skylaunch::utils::AddrFromBase(0x710128a9e0);
+			else if(xenomods::version::RuntimeVersion() == xenomods::version::SemVer::v2_2_0)
+				getMemoryInfo = skylaunch::utils::AddrFromBase(0x710128b550);
 
-                return ((bool (*) (mtl::ALLOC_HANDLE, mtl::MemoryInfo*)) getMemoryInfo)(handle, out);
+			return ((bool (*)(mtl::ALLOC_HANDLE, mtl::MemoryInfo*))getMemoryInfo)(handle, out);
 #endif
-            }
-    };
+		}
+	};
 
-}
+} // namespace mtl

--- a/include/xenomods/engine/mtl/MemManager.hpp
+++ b/include/xenomods/engine/mtl/MemManager.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "Allocator.hpp"
+#include "MemoryInfo.hpp"
+
+namespace mtl {
+
+    class MemManager {
+        public:
+            static bool getMemoryInfo(mtl::ALLOC_HANDLE, mtl::MemoryInfo *);
+    };
+
+}

--- a/include/xenomods/engine/mtl/MemManager.hpp
+++ b/include/xenomods/engine/mtl/MemManager.hpp
@@ -2,12 +2,33 @@
 
 #include "Allocator.hpp"
 #include "MemoryInfo.hpp"
+#include "xenomods/Version.hpp"
 
 namespace mtl {
 
     class MemManager {
         public:
-            static bool getMemoryInfo(mtl::ALLOC_HANDLE, mtl::MemoryInfo *);
+            static bool getMemoryInfo(mtl::ALLOC_HANDLE, mtl::MemoryInfo*);
+
+            // xenomods
+            /// `mtl::MemoryInfo` accessor compatible with all games
+            static bool GET_MEMORY_INFO(mtl::ALLOC_HANDLE handle, mtl::MemoryInfo* out) {
+#if !XENOMODS_CODENAME(bf3)
+                return getMemoryInfo(handle, out);
+#else
+                uintptr_t getMemoryInfo;
+                if (xenomods::version::RuntimeVersion() == xenomods::version::SemVer::v2_0_0)
+                    getMemoryInfo = skylaunch::utils::AddrFromBase(0x710128a670);
+                else if (xenomods::version::RuntimeVersion() == xenomods::version::SemVer::v2_1_0)
+                    getMemoryInfo = skylaunch::utils::AddrFromBase(0x710128a9a0);
+                else if (xenomods::version::RuntimeVersion() == xenomods::version::SemVer::v2_1_1)
+                    getMemoryInfo = skylaunch::utils::AddrFromBase(0x710128a9e0);
+                else if (xenomods::version::RuntimeVersion() == xenomods::version::SemVer::v2_2_0)
+                    getMemoryInfo = skylaunch::utils::AddrFromBase(0x710128b550);
+
+                return ((bool (*) (mtl::ALLOC_HANDLE, mtl::MemoryInfo*)) getMemoryInfo)(handle, out);
+#endif
+            }
     };
 
 }

--- a/include/xenomods/engine/mtl/MemoryInfo.hpp
+++ b/include/xenomods/engine/mtl/MemoryInfo.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+namespace mtl {
+
+    struct MemoryInfo {
+        public:
+            size_t totalSize;
+            size_t availableSize;
+            size_t allocatedSize;
+            size_t largestFreeSize;
+            float usedPercent;
+            float allocatedChunksPercent;
+            uint32_t fullyAllocatedChunks;
+            size_t topAddress;
+            const char *regionName;
+
+#if XENOMODS_CODENAME(bf3)
+            mtl::AllocatorType allocatorType;
+#endif 
+
+    };
+
+}

--- a/include/xenomods/engine/mtl/MemoryInfo.hpp
+++ b/include/xenomods/engine/mtl/MemoryInfo.hpp
@@ -22,11 +22,12 @@ namespace mtl {
 		///
 		/// This is always zero for `ALLOCATOR_BF3`.
 		size_t largestFreeSize;
-		///
+		/// Percentage ratio of allocated size vs total size, i.e. `allocatedSize * 100 / totalSize`.
+        ///
 		/// Normally ranges from 0.0 to 100.0, but due to the inconsistencies explained above
 		/// it could be higher for `ALLOCATOR_BF3`.
 		float usedPercent;
-		/// Percentage ratio of occupied chunks vs total chunks in the region.
+		/// Percentage ratio of occupied chunks vs total chunks in the region. (0-100)
 		/// A low value indicates many short-lived allocations, high fragmentation, or both.
 		///
 		/// This is always zero for `ALLOCATOR_BF3`.

--- a/include/xenomods/engine/mtl/MemoryInfo.hpp
+++ b/include/xenomods/engine/mtl/MemoryInfo.hpp
@@ -2,51 +2,50 @@
 
 namespace mtl {
 
-    /// Populated by `mtl::MemManager::getMemoryInfo`
-    struct MemoryInfo {
-        public:
-            /// Total size of the region, in bytes.
-            ///
-            /// For `ALLOCATOR_BF3`, this isn't always accurate because the allocator doesn't seem
-            /// to actually enforce the limit, additionally it is sometimes zero for those regions.
-            size_t totalSize;
-            /// Bytes available for new allocations, this seems to always be
-            /// `totalSize - allocatedSize`.
-            ///
-            /// For `ALLOCATOR_BF3`, this has the same inconsistencies as `totalSize`.
-            size_t availableSize;
-            /// Total bytes reserved for existing allocations, including allocation overhead.
-            size_t allocatedSize;
-            /// The size of the largest contiguous block available for new allocations,
-            /// a low value with much available space left indicates high fragmentation.
-            ///
-            /// This is always zero for `ALLOCATOR_BF3`.
-            size_t largestFreeSize;
-            /// 
-            /// Normally ranges from 0.0 to 100.0, but due to the inconsistencies explained above
-            /// it could be higher for `ALLOCATOR_BF3`.
-            float usedPercent;
-            /// Percentage ratio of occupied chunks vs total chunks in the region.
-            /// A low value indicates many short-lived allocations, high fragmentation, or both.
-            ///
-            /// This is always zero for `ALLOCATOR_BF3`.
-            float occupiedChunksPercent;
-            /// Number of chunks that are fully occupied, i.e. perfectly aligned.
-            uint32_t fullyAllocatedChunks;
-            /// First address in the region.
-            ///
-            /// This seems to be zero for `ALLOCATOR_BF3`.
-            size_t topAddress;
-            /// The name assigned to the memory region.
-            ///
-            /// As is common in that game, all names are empty in Xenoblade 3. 
-            const char *regionName;
+	/// Populated by `mtl::MemManager::getMemoryInfo`
+	struct MemoryInfo {
+	   public:
+		/// Total size of the region, in bytes.
+		///
+		/// For `ALLOCATOR_BF3`, this isn't always accurate because the allocator doesn't seem
+		/// to actually enforce the limit, additionally it is sometimes zero for those regions.
+		size_t totalSize;
+		/// Bytes available for new allocations, this seems to always be
+		/// `totalSize - allocatedSize`.
+		///
+		/// For `ALLOCATOR_BF3`, this has the same inconsistencies as `totalSize`.
+		size_t availableSize;
+		/// Total bytes reserved for existing allocations, including allocation overhead.
+		size_t allocatedSize;
+		/// The size of the largest contiguous block available for new allocations,
+		/// a low value with much available space left indicates high fragmentation.
+		///
+		/// This is always zero for `ALLOCATOR_BF3`.
+		size_t largestFreeSize;
+		///
+		/// Normally ranges from 0.0 to 100.0, but due to the inconsistencies explained above
+		/// it could be higher for `ALLOCATOR_BF3`.
+		float usedPercent;
+		/// Percentage ratio of occupied chunks vs total chunks in the region.
+		/// A low value indicates many short-lived allocations, high fragmentation, or both.
+		///
+		/// This is always zero for `ALLOCATOR_BF3`.
+		float occupiedChunksPercent;
+		/// Number of chunks that are fully occupied, i.e. perfectly aligned.
+		uint32_t fullyAllocatedChunks;
+		/// First address in the region.
+		///
+		/// This seems to be zero for `ALLOCATOR_BF3`.
+		size_t topAddress;
+		/// The name assigned to the memory region.
+		///
+		/// As is common in that game, all names are empty in Xenoblade 3.
+		const char* regionName;
 
 #if XENOMODS_CODENAME(bf3)
-            /// Only present in Xenoblade 3
-            mtl::AllocatorType allocatorType;
-#endif 
+		/// Only present in Xenoblade 3
+		mtl::AllocatorType allocatorType;
+#endif
+	};
 
-    };
-
-}
+} // namespace mtl

--- a/include/xenomods/engine/mtl/MemoryInfo.hpp
+++ b/include/xenomods/engine/mtl/MemoryInfo.hpp
@@ -2,19 +2,48 @@
 
 namespace mtl {
 
+    /// Populated by `mtl::MemManager::getMemoryInfo`
     struct MemoryInfo {
         public:
+            /// Total size of the region, in bytes.
+            ///
+            /// For `ALLOCATOR_BF3`, this isn't always accurate because the allocator doesn't seem
+            /// to actually enforce the limit, additionally it is sometimes zero for those regions.
             size_t totalSize;
+            /// Bytes available for new allocations, this seems to always be
+            /// `totalSize - allocatedSize`.
+            ///
+            /// For `ALLOCATOR_BF3`, this has the same inconsistencies as `totalSize`.
             size_t availableSize;
+            /// Total bytes reserved for existing allocations, including allocation overhead.
             size_t allocatedSize;
+            /// The size of the largest contiguous block available for new allocations,
+            /// a low value with much available space left indicates high fragmentation.
+            ///
+            /// This is always zero for `ALLOCATOR_BF3`.
             size_t largestFreeSize;
+            /// 
+            /// Normally ranges from 0.0 to 100.0, but due to the inconsistencies explained above
+            /// it could be higher for `ALLOCATOR_BF3`.
             float usedPercent;
-            float allocatedChunksPercent;
+            /// Percentage ratio of occupied chunks vs total chunks in the region.
+            /// A low value indicates many short-lived allocations, high fragmentation, or both.
+            ///
+            /// This is always zero for `ALLOCATOR_BF3`.
+            float occupiedChunksPercent;
+            /// Number of chunks that are fully occupied, i.e. perfectly aligned.
             uint32_t fullyAllocatedChunks;
+            /// First address in the region.
+            ///
+            /// This seems to be zero for `ALLOCATOR_BF3`.
             size_t topAddress;
+            /// The name assigned to the memory region.
+            ///
+            /// As is common in that game, all names are empty in Xenoblade 3. 
             const char *regionName;
 
 #if XENOMODS_CODENAME(bf3)
+            /// Only present in Xenoblade 3
             mtl::AllocatorType allocatorType;
 #endif 
 

--- a/include/xenomods/menu/Menu.hpp
+++ b/include/xenomods/menu/Menu.hpp
@@ -17,6 +17,7 @@ namespace xenomods {
 
 		std::vector<Section*> sections {};
 		std::vector<void(*)()> callbacks {};
+		std::vector<void(*)()> backgroundCallbacks {};
 
 	   public:
 		void Initialize();
@@ -49,7 +50,7 @@ namespace xenomods {
 
 		Section* FindSection(const std::string& key);
 		Section* RegisterSection(const std::string& key, const std::string& display);
-		void RegisterRenderCallback(void(*func)());
+		void RegisterRenderCallback(void(*func)(), bool foregroundOnly);
 
 		friend class Section;
 

--- a/src/xenomods/main.cpp
+++ b/src/xenomods/main.cpp
@@ -15,6 +15,7 @@
 #include <imgui_xeno.h>
 #include <imgui.h>
 #include "modules/RenderingControls.hpp"
+#include "helpers/InputHelper.h"
 
 namespace xenomods {
 
@@ -47,7 +48,8 @@ namespace xenomods {
 		xenomods::UpdateAllRegisteredModules(updateInfo);
 
 		// render the menu if open
-		if(g_Menu->IsOpen())
+		InputHelper::toggleInput = g_Menu->IsOpen();
+		if (g_Menu->IsOpen())
 			g_Menu->Update(menuInput);
 
 		// draw logger messages and toasts

--- a/src/xenomods/menu/Menu.cpp
+++ b/src/xenomods/menu/Menu.cpp
@@ -173,6 +173,10 @@ namespace xenomods {
 	}
 
 	void Menu::Render() {
+		for(auto func : g_Menu->backgroundCallbacks) {
+			func();
+		}
+
 		if (!g_Menu->IsOpen())
 			return;
 
@@ -277,9 +281,14 @@ namespace xenomods {
 		return sec;
 	}
 
-	void Menu::RegisterRenderCallback(void (*func)()) {
-		if (func != nullptr)
+	void Menu::RegisterRenderCallback(void (*func)(), bool foregroundOnly) {
+		if (func == nullptr)
+			return;
+		
+		if (foregroundOnly)
 			callbacks.push_back(func);
+		else
+			backgroundCallbacks.push_back(func);
 	}
 
 	// The menu instance.

--- a/src/xenomods/menu/Menu.cpp
+++ b/src/xenomods/menu/Menu.cpp
@@ -165,8 +165,7 @@ namespace xenomods {
 	static double lastUpdateDiff = 0;
 	void Menu::Update(HidInput* input) {
 		InputHelper::setPort(input->padId);
-		InputHelper::toggleInput = g_Menu->IsOpen();
-
+		
 		auto seconds = nn::os::GetSystemTick()/19200000.;
 		lastUpdateDiff = seconds - lastUpdateSeconds;
 		lastUpdateSeconds = seconds;

--- a/src/xenomods/menu/Menu.cpp
+++ b/src/xenomods/menu/Menu.cpp
@@ -177,7 +177,7 @@ namespace xenomods {
 			func();
 		}
 
-		if (!g_Menu->IsOpen())
+		if(!g_Menu->IsOpen())
 			return;
 
 		if (g_Menu->logOpen)
@@ -282,10 +282,10 @@ namespace xenomods {
 	}
 
 	void Menu::RegisterRenderCallback(void (*func)(), bool foregroundOnly) {
-		if (func == nullptr)
+		if(func == nullptr)
 			return;
-		
-		if (foregroundOnly)
+
+		if(foregroundOnly)
 			callbacks.push_back(func);
 		else
 			backgroundCallbacks.push_back(func);

--- a/src/xenomods/modules/DebugStuff.cpp
+++ b/src/xenomods/modules/DebugStuff.cpp
@@ -257,9 +257,8 @@ namespace xenomods {
 		static int lastActiveRegions;
 
 		mtl::AllocHandle allocHandle { 0 };
-		bool open = true;
 
-		if(!ImGui::Begin("Memory", &open)) {
+		if(!ImGui::Begin("Memory", &DebugStuff::enableMemoryDebug)) {
 			ImGui::End();
 			return;
 		}

--- a/src/xenomods/modules/DebugStuff.cpp
+++ b/src/xenomods/modules/DebugStuff.cpp
@@ -238,31 +238,31 @@ namespace xenomods {
 #if XENOMODS_CODENAME(bf3)
 		unsigned int* s_flg = nullptr; //ml::_dsk::s_flg
 
-		if (version::RuntimeVersion() == version::SemVer::v2_0_0)
+		if(version::RuntimeVersion() == version::SemVer::v2_0_0)
 			s_flg = reinterpret_cast<unsigned int*>(skylaunch::utils::AddrFromBase(0x7101c49c60));
-		else if (version::RuntimeVersion() == version::SemVer::v2_1_0 || version::RuntimeVersion() == version::SemVer::v2_1_1 || version::RuntimeVersion() == version::SemVer::v2_2_0)
+		else if(version::RuntimeVersion() == version::SemVer::v2_1_0 || version::RuntimeVersion() == version::SemVer::v2_1_1 || version::RuntimeVersion() == version::SemVer::v2_2_0)
 			s_flg = reinterpret_cast<unsigned int*>(skylaunch::utils::AddrFromBase(0x7101c4ac60));
 
 		// sets the system info print to display
-		if (s_flg != nullptr)
+		if(s_flg != nullptr)
 			*s_flg ^= (-enableDebugRendering ^ *s_flg) & (1 << 6);
 #endif
 	}
 
 	void DebugStuff::MemoryDebugRendering() {
-		if (!DebugStuff::enableMemoryDebug)
+		if(!DebugStuff::enableMemoryDebug)
 			return;
 
 		mtl::MemoryInfo memInfo {};
-		mtl::AllocHandle allocHandle {0};
+		mtl::AllocHandle allocHandle { 0 };
 		bool open = true;
 
-		if (!ImGui::Begin("Memory", &open)) {
+		if(!ImGui::Begin("Memory", &open)) {
 			ImGui::End();
 			return;
 		}
 
-		if (ImGui::BeginTable("memdbg", 5)) {
+		if(ImGui::BeginTable("memdbg", 5)) {
 			// Headers
 			ImGui::TableSetupColumn("ID", ImGuiTableColumnFlags_WidthFixed, 20.0);
 			ImGui::TableSetupColumn("Name");
@@ -271,9 +271,9 @@ namespace xenomods {
 			ImGui::TableSetupColumn("Total (MB)");
 			ImGui::TableHeadersRow();
 
-			for (int i = 1; i < 512; i++) {
+			for(int i = 1; i < 512; i++) {
 				allocHandle.regionId = i;
-				if (!mtl::MemManager::GET_MEMORY_INFO(&allocHandle, &memInfo)) {
+				if(!mtl::MemManager::GET_MEMORY_INFO(&allocHandle, &memInfo)) {
 					break;
 				}
 				ImGui::TableNextRow();
@@ -286,28 +286,24 @@ namespace xenomods {
 
 				// Used % progress bar
 				ImU32 color;
-				if (memInfo.usedPercent >= 90) 
+				if(memInfo.usedPercent >= 90)
 					color = IM_COL32(161, 21, 13, 255);
-				else if (memInfo.usedPercent >= 50)
+				else if(memInfo.usedPercent >= 50)
 					color = IM_COL32(163, 108, 13, 255);
 				else
 					color = IM_COL32(28, 82, 52, 255);
 				ImGui::TableNextColumn();
 				ImGui::PushStyleColor(ImGuiCol_PlotHistogram, color);
-				ImGui::ProgressBar(
-					memInfo.usedPercent / 100, 
-					ImVec2(ImGui::GetFontSize() * 10, 0.0f), 
-					std::format("{:.1f}%", memInfo.usedPercent).c_str()
-				);
+				ImGui::ProgressBar(memInfo.usedPercent / 100, ImVec2(ImGui::GetFontSize() * 10, 0.0f), std::format("{:.1f}%", memInfo.usedPercent).c_str());
 				ImGui::PopStyleColor(1);
 
 				ImGui::TableNextColumn();
 				ImGui::Text("%.4f", memInfo.allocatedSize / 1e6);
 				ImGui::TableNextColumn();
-				ImGui::Text("%d %.4f", memInfo.allocatorType, memInfo.totalSize / 1e6);
+				ImGui::Text("%.4f", memInfo.totalSize / 1e6);
 			}
-            ImGui::EndTable();
-        }
+			ImGui::EndTable();
+		}
 
 		ImGui::End();
 	}
@@ -382,7 +378,7 @@ namespace xenomods {
 	void DebugStuff::Update(fw::UpdateInfo* updateInfo) {
 		bgmTrackIndex = 0;
 
-		if (pauseEnable && pauseStepForward > 0) {
+		if(pauseEnable && pauseStepForward > 0) {
 			pauseStepForward--;
 		}
 	}

--- a/src/xenomods/modules/DebugStuff.cpp
+++ b/src/xenomods/modules/DebugStuff.cpp
@@ -262,17 +262,18 @@ namespace xenomods {
 			return;
 		}
 
-		if (ImGui::BeginTable("mem", 4)) {
+		if (ImGui::BeginTable("memdbg", 5)) {
 			// Headers
 			ImGui::TableSetupColumn("ID", ImGuiTableColumnFlags_WidthFixed, 20.0);
 			ImGui::TableSetupColumn("Name");
 			ImGui::TableSetupColumn("Used %");
 			ImGui::TableSetupColumn("Allocated (MB)");
+			ImGui::TableSetupColumn("Total (MB)");
 			ImGui::TableHeadersRow();
 
 			for (int i = 1; i < 512; i++) {
 				allocHandle.regionId = i;
-				if (!mtl::MemManager::getMemoryInfo(&allocHandle, &memInfo)) {
+				if (!mtl::MemManager::GET_MEMORY_INFO(&allocHandle, &memInfo)) {
 					break;
 				}
 				ImGui::TableNextRow();
@@ -302,6 +303,8 @@ namespace xenomods {
 
 				ImGui::TableNextColumn();
 				ImGui::Text("%.4f", memInfo.allocatedSize / 1e6);
+				ImGui::TableNextColumn();
+				ImGui::Text("%d %.4f", memInfo.allocatorType, memInfo.totalSize / 1e6);
 			}
             ImGui::EndTable();
         }
@@ -312,6 +315,7 @@ namespace xenomods {
 	void DebugStuff::MenuSection() {
 		if(ImGui::Checkbox("Enable debug rendering", &DebugStuff::enableDebugRendering))
 			DebugStuff::UpdateDebugRendering();
+		ImGui::Checkbox("Memory debug window", &DebugStuff::enableMemoryDebug);
 
 		/*ImGui::Checkbox("Pause updates", &DebugStuff::pauseEnable);
 		ImGui::SameLine();
@@ -341,7 +345,6 @@ namespace xenomods {
 		if(ImGui::Button("Return to Title"))
 			DebugStuff::ReturnTitle();
 #endif
-		ImGui::Checkbox("Memory debug rendering", &DebugStuff::enableMemoryDebug);
 	}
 
 	void DebugStuff::Initialize() {

--- a/src/xenomods/modules/DebugStuff.hpp
+++ b/src/xenomods/modules/DebugStuff.hpp
@@ -10,6 +10,7 @@ namespace xenomods {
 		static bool enableDebugUnlockAll;
 		static bool accessClosedLandmarks;
 		static bool pauseEnable;
+		static bool enableMemoryDebug;
 
 		static std::int8_t pauseStepForward;
 		static int tempInt;
@@ -26,6 +27,7 @@ namespace xenomods {
 		static void ReturnTitle(unsigned int slot = -1);
 
 		static void UpdateDebugRendering();
+		static void MemoryDebugRendering();
 
 		static void MenuSection();
 

--- a/src/xenomods/modules/PlayerMovement.cpp
+++ b/src/xenomods/modules/PlayerMovement.cpp
@@ -597,7 +597,7 @@ namespace xenomods {
 			state->RegisterRenderCallback(&MenuState);
 		}
 
-		g_Menu->RegisterRenderCallback(&MenuWarps);
+		g_Menu->RegisterRenderCallback(&MenuWarps, true);
 #endif
 	}
 


### PR DESCRIPTION
This PR adds a debug window for memory allocations, leveraging the API provided by `mtl::MemManager::getMemoryInfo`, present in all three games. It shows stats like usage and total size for the allocation arenas the games use.

The results are somewhat consistent across all games, with the exception of the new allocator in XC3 behaving a bit weirdly when it comes to memory stats. Essentially, it accepts 0 as the "total size" (in this case, it reports the used size, but 0% as the ratio), and often reports allocated size > total size (with > 100% ratio), which leads me to believe it doesn't actually enforce the size limits.

The menu can be enabled from the "Debug Stuff" submenu in the main menu bar.

As for changes to existing code:

* I think the definition of `mtl::ALLOC_HANDLE` was wrong, in all three games it seems to be a pointer to an `int` between 1 and 511. I needed to mutate that value so I named the pointee `mtl::AllocHandle`, though I think that in game this is just a wrapper over `int*`.
* For the debug window, I added a parameter to `Menu::RegisterRenderCallback` that lets you register callbacks that aren't "foreground only", i.e. they are also run when the menu is not shown.

Please let me know if you have any questions or if you'd like any changes to be made.